### PR TITLE
Fix Solana-only GoPlus security scan

### DIFF
--- a/scripts/security_check.py
+++ b/scripts/security_check.py
@@ -1,16 +1,17 @@
 """Automated token security checking using GoPlus APIs.
 
-Phase 1 uses the general token security batch API.
-Phase 2 queries the Solana-specific API for tokens still pending.
+The GoPlus "general" token security endpoint no longer allows Solana
+checks, so this script exclusively uses the Solana-specific endpoint.
 
-Major risk flags used to mark tokens as ``DANGER``. These sets can be
-extended in the future to tweak how risky tokens are evaluated.
+Tokens are queried sequentially and the script respects GoPlus's limit
+of 30 requests per 60 seconds (an extra second of buffer is included).
 
-- **General**: ``is_honeypot``, ``is_blacklisted``, ``is_proxy``,
-  ``can_take_back_ownership``, ``owner_change_balance``, ``trading_paused``,
-  ``anti_bot``
-- **Solana**: ``mint_authority_exist``, ``freeze_authority_exist``,
-  ``trading_paused``, ``anti_bot``
+Major risk flags used to mark tokens as ``DANGER`` can be extended in the
+future to tweak how risky tokens are evaluated. Only the Solana specific
+set is currently used:
+
+``mint_authority_exist``, ``freeze_authority_exist``, ``trading_paused``,
+``anti_bot``.
 """
 
 from __future__ import annotations
@@ -34,17 +35,16 @@ CSV_PATH = os.getenv(
 )
 LOG_FILE = os.path.join(LOG_DIR, "data_collection.log")
 
-# API endpoints
-# General endpoint expects the chain_id path parameter. The Solana specific
-# endpoint is used for detailed checks in phase 2.
-GENERAL_URL = "https://api.gopluslabs.io/api/v1/token_security"
-CHAIN_ID = "101"  # Solana
+# API endpoint
+# Only the Solana-specific token security API is supported.
 SOLANA_URL = "https://api.gopluslabs.io/api/v1/solana/token_security"
 
 # API limits
-GENERAL_BATCH = 50  # max addresses per batch (per docs)
-GENERAL_RATE_DELAY = 2  # seconds between requests (30/min)
-SOLANA_RATE_DELAY = 1   # one per second
+# GoPlus allows 30 requests per minute. We use 61 seconds for 30 requests
+# to stay safely under the cap.
+RATE_LIMIT = 30
+RATE_WINDOW = 61  # seconds
+SOLANA_RATE_DELAY = RATE_WINDOW / RATE_LIMIT
 
 # Columns from GitHub template
 HEADERS = [
@@ -120,16 +120,6 @@ HEADERS = [
     "notes",
 ]
 
-MAJOR_RISKS_GENERAL = {
-    "is_honeypot",
-    "is_blacklisted",
-    "is_proxy",
-    "can_take_back_ownership",
-    "owner_change_balance",
-    "trading_paused",
-    "anti_bot",
-}
-
 MAJOR_RISKS_SOLANA = {
     "mint_authority_exist",
     "freeze_authority_exist",
@@ -164,11 +154,6 @@ def save_csv(df: pd.DataFrame) -> None:
     df.to_csv(CSV_PATH, index=False)
 
 
-def batch(iterable: List[str], n: int) -> List[List[str]]:
-    for i in range(0, len(iterable), n):
-        yield iterable[i : i + n]
-
-
 def parse_top_holder_fields(info: Dict[str, Any]) -> Dict[str, Any]:
     """Extract LP and top holder information from API response."""
     parsed: Dict[str, Any] = {}
@@ -200,65 +185,6 @@ def parse_top_holder_fields(info: Dict[str, Any]) -> Dict[str, Any]:
     return parsed
 
 
-def fetch_general(addresses: List[str]) -> Dict[str, Any]:
-    params = {"contract_addresses": ",".join(addresses)}
-    try:
-        url = f"{GENERAL_URL}/{CHAIN_ID}"
-        resp = requests.get(url, params=params, timeout=10)
-        resp.raise_for_status()
-        logging.debug("General API raw response: %s", resp.text)
-        data = resp.json().get("result", {})
-        if data is None:
-            data = {}
-        return data
-    except Exception as exc:
-        logging.error("General API error for %s: %s", addresses, exc)
-        return {}
-
-
-def update_from_general(
-    df: pd.DataFrame, batch_addresses: List[str], results: Dict[str, Any]
-) -> None:
-    now = datetime.now(timezone.utc).isoformat()
-    for addr in batch_addresses:
-        info = results.get(addr, {})
-        row_mask = df["mint_address"].str.lower() == addr.lower()
-        if not row_mask.any():
-            continue
-        if info:
-            for key, value in info.items():
-                if key not in df.columns:
-                    df[key] = ""
-                if isinstance(value, (list, dict)):
-                    df.loc[row_mask, key] = json.dumps(value)
-                else:
-                    df.loc[row_mask, key] = value
-            holders = parse_top_holder_fields(info)
-            for key, value in holders.items():
-                if key not in df.columns:
-                    df[key] = ""
-                df.loc[row_mask, key] = value
-        else:
-            df.loc[row_mask, "security_status"] = "NO_DATA"
-            df.loc[row_mask, "health_summary"] = "No data from GoPlus"
-            df.loc[row_mask, "last_updated"] = now
-            continue
-        # first_seen_on
-        if df.loc[row_mask, "first_seen_on"].isna().any() or (df.loc[row_mask, "first_seen_on"] == "").any():
-            df.loc[row_mask, "first_seen_on"] = now
-        df.loc[row_mask, "last_updated"] = now
-        status = "PENDING"
-        triggered = []
-        for risk in MAJOR_RISKS_GENERAL:
-            if str(info.get(risk, "0")) in {"1", "True", "true"}:
-                status = "DANGER"
-                triggered.append(risk)
-        df.loc[row_mask, "security_status"] = status
-        if status == "DANGER" and triggered:
-            summary = f"Danger—{','.join(triggered)}"
-        else:
-            summary = "Safe"
-        df.loc[row_mask, "health_summary"] = summary
 
 
 def fetch_solana(address: str) -> Dict[str, Any]:
@@ -289,8 +215,13 @@ def update_from_solana(df: pd.DataFrame, address: str, info: Dict[str, Any]) -> 
                 df.loc[row_mask, key] = json.dumps(value)
             else:
                 df.loc[row_mask, key] = value
-        status = df.loc[row_mask, "security_status"].iloc[0]
-        danger = status == "DANGER"
+        holders = parse_top_holder_fields(info)
+        for key, value in holders.items():
+            if key not in df.columns:
+                df[key] = ""
+            df.loc[row_mask, key] = value
+
+        danger = False
         triggered = []
         for risk in MAJOR_RISKS_SOLANA:
             if str(info.get(risk, "0")) in {"1", "True", "true"}:
@@ -315,20 +246,11 @@ def main() -> None:
     to_check = df[df["security_status"].fillna("").str.upper().isin(["", "PENDING", "UNKNOWN"])]
     addresses = to_check["mint_address"].dropna().tolist()
     checked_count = len(addresses)
-    logging.info("General security check for %d tokens", checked_count)
+    logging.info("Solana security check for %d tokens", checked_count)
 
-    for batch_addresses in batch(addresses, GENERAL_BATCH):
-        results = fetch_general(batch_addresses)
-        update_from_general(df, batch_addresses, results)
-        sleep(GENERAL_RATE_DELAY)
-
-    pending = df[df["security_status"] == "PENDING"]["mint_address"].tolist()
-    logging.info("Solana security check for %d tokens", len(pending))
-    checked_count += len(pending)
-    for addr in pending:
+    for addr in addresses:
         info = fetch_solana(addr)
-        if info:
-            update_from_solana(df, addr, info)
+        update_from_solana(df, addr, info)
         sleep(SOLANA_RATE_DELAY)
 
     save_csv(df)


### PR DESCRIPTION
## Summary
- drop support for the general GoPlus token security endpoint
- call the Solana-specific endpoint for every token
- enforce GoPlus rate limit of 30 requests per 61 seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd23a7b108330a24ca25582311889